### PR TITLE
snapcraft.yaml: update build + install usage to override-build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -27,8 +27,10 @@ parts:
     build-packages: [golang-go, g++]
     source: https://go.googlesource.com/go
     source-type: git
-    build: cd src && env GOROOT_BOOTSTRAP=$(go env GOROOT | tr -d '\n') ./make.bash
-    install: cp -R * $SNAPCRAFT_PART_INSTALL
+    override-build: |
+      cd src && env GOROOT_BOOTSTRAP=$(go env GOROOT | tr -d '\n') ./make.bash
+      cd ..
+      cp -R bin $SNAPCRAFT_PART_INSTALL
     stage:
       - 'bin'
     prime:


### PR DESCRIPTION
See deprecation notices DN8 + DN9
https://docs.snapcraft.io/deprecation-notices/dn9
https://docs.snapcraft.io/deprecation-notices/dn8

This should make the deprecation notices go away for all snaps that build with the `go` remote part.